### PR TITLE
Implement transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A pure Julia MonetDB connector.
 
 ## Usage
 
+### Execute
+
 ```julia
 MonetDB.connect("localhost", 50000, "monetdb", "monetdb", "demo")
 
@@ -16,3 +18,15 @@ df = MonetDB.execute(conn, "SELECT 1 AS \"foo\",2 AS \"bar\"")
    1 │ 1       2
 ```
 
+### Transaction
+
+Additionally, a transaction can also be started:
+
+```julia
+MonetDB.connect("localhost", 50000, "monetdb", "monetdb", "demo")
+
+MonetDB.transaction(conn) do
+   MonetDB.execute(conn, "INSERT INTO my_table VALUES ('foo')")
+end
+
+```

--- a/src/MonetDB.jl
+++ b/src/MonetDB.jl
@@ -17,4 +17,15 @@ function execute(conn, cmd)
     return mapi_execute(conn, cmd)
 end
 
+"""
+Use a transaction to complete the statement.
+"""
+function transaction(f::Function, conn)
+    mapi_execute(conn, "start transaction")
+
+    f()
+
+    mapi_execute(conn, "commit")
+end
+
 end # module MonetDB

--- a/src/MonetDB.jl
+++ b/src/MonetDB.jl
@@ -23,7 +23,12 @@ Use a transaction to complete the statement.
 function transaction(f::Function, conn)
     mapi_execute(conn, "start transaction")
 
-    f()
+    try
+        f()
+    catch
+        mapi_execute(conn, "rollback")
+        return
+    end
 
     mapi_execute(conn, "commit")
 end


### PR DESCRIPTION
Implement a WIP version of the transaction function, which allows a block of code to be ran inside a transaction:

```julia
MonetDB.transaction(conn) do

end
```

However, this needs a bit more work regarding the autocommit.